### PR TITLE
Update INDINumberElement.java

### DIFF
--- a/app/src/main/java/laazotea/indi/client/INDINumberElement.java
+++ b/app/src/main/java/laazotea/indi/client/INDINumberElement.java
@@ -126,6 +126,10 @@ public class INDINumberElement extends INDIElement {
       newNumberFormat = "%.0f";  
     }
     
+    if (newNumberFormat.equals("%.f")) {
+      newNumberFormat = "%.0f";  
+    }
+    
     this.numberFormat = newNumberFormat;
   }
 


### PR DESCRIPTION
Connecting to INDI running on a RPi2 I was getting the app crashing, installed Android Studio and built to diagnose the crash, turns out it was sending "%.f" as format strings, which causes exceptions calling formatter.format
Example string it was receiving: <defNumber name="TIMED_GUIDE_N" label="North (ms)" format="%.f" min="0" max="60000" step="100">